### PR TITLE
無題状態で立ち上げた時に発生するNullReferenceExceptionの修正

### DIFF
--- a/MarkDownSharpEditor/Form1.cs
+++ b/MarkDownSharpEditor/Form1.cs
@@ -15,7 +15,7 @@ using System.Runtime.InteropServices;
 using System.Windows.Documents;
 
 using anrControls;
-using mshtml;
+using MSHTML;
 
 namespace MarkDownSharpEditor
 {
@@ -1249,7 +1249,11 @@ namespace MarkDownSharpEditor
 				ResultText = Encoding.GetEncoding(CodePageNum).GetString(bytesData);
 				//TODO: クリック音対策
 				//webBrowser1.DocumentText = MkResultText;
-				if (webBrowser1.Document != null)
+                if (webBrowser1.Document == null)
+                {
+                    webBrowser1.Navigate("about:blank");
+                }
+				else if (webBrowser1.Document != null)
 				{
 					webBrowser1.Document.OpenNew(true);
 				}


### PR DESCRIPTION
#7 が対応されたVer.1.1.5.0を無題状態で立ち上げたときにNullReferenceExceptionが発生してしまう問題を発見､デバッグできたので修正してみました｡

Githubの練習も兼ねてPull Requestにしてみましたが､よく分かっておらずです｡すみません....1250行目付近のコードが修正部分ですので､ご確認いただければ幸いです｡

手元の環境でビルドが通らずMSHTMLの参照設定を変更したのですが､その結果､冒頭のusing宣言も変えることになってしまいました｡紛らわしくてすみません｡
