### PR TITLE
Remove End-of-line conversion

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,5 +1,5 @@
 # Auto detect text files and perform LF normalization
-* text=auto
+* -text
 
 # Custom for Visual Studio
 *.cs     diff=csharp

--- a/MarkDownSharpEditor/Form1.cs
+++ b/MarkDownSharpEditor/Form1.cs
@@ -48,8 +48,7 @@ namespace MarkDownSharpEditor
 		private Encoding _EditingFileEncoding = Encoding.UTF8;             //編集中MDファイルの文字エンコーディング ( Character encoding of MD file editing )
 
 		private bool _fConstraintChange = true;	                           //更新状態の抑制 ( Constraint changing flag )
-		private ArrayList _MarkdownSyntaxKeywordAarray = new ArrayList();  // Array of MarkdownSyntaxKeyword Class
-
+		private ICollection<MarkdownSyntaxKeyword> _MarkdownSyntaxKeywordAarray;
 		//-----------------------------------
 		// コンストラクタ ( Constructor )
 		//-----------------------------------
@@ -157,7 +156,7 @@ namespace MarkDownSharpEditor
 
 			//エディターのシンタックスハイライター設定の反映
 			//Syntax highlighter of editor window is enabled 
-			RefreshSyntaxHightlighterKeyword();
+			_MarkdownSyntaxKeywordAarray = MarkdownSyntaxKeyword.CreateKeywordList();
 
 			//-----------------------------------
 			//選択中のエンコーディングを表示
@@ -1399,8 +1398,7 @@ namespace MarkDownSharpEditor
 			var result = new List<SyntaxColorScheme>();
 			foreach (MarkdownSyntaxKeyword mk in _MarkdownSyntaxKeywordAarray)
 			{
-				Regex r = new Regex(mk.RegText, RegexOptions.Multiline | RegexOptions.IgnoreCase | RegexOptions.Compiled);
-				MatchCollection col = r.Matches(text, 0);
+				MatchCollection col = mk.Regex.Matches(text, 0);
 				
 				if (col.Count > 0)
 				{
@@ -1839,98 +1837,6 @@ namespace MarkDownSharpEditor
 		}
 
 
-		//----------------------------------------------------------------------
-		// シンタックス・ハイライター（Regex）のキーワード更新
-		// Refresh regular expression of syntax hightlighter keyword
-		//----------------------------------------------------------------------
-		private void RefreshSyntaxHightlighterKeyword()
-		{
-			var obj = MarkDownSharpEditor.AppSettings.Instance;
-			_MarkdownSyntaxKeywordAarray.Clear();
-
-			//-----------------------------------
-			// Markdown SyntaxHighlighter
-			//-----------------------------------
-			//強制ブレーク ( Line break )
-			_MarkdownSyntaxKeywordAarray.Add(new MarkdownSyntaxKeyword(@"  $", Color.FromArgb(obj.ForeColor_LineBreak), Color.FromArgb(obj.BackColor_LineBreak)));
-			//見出し１ ( Header 1 )
-			_MarkdownSyntaxKeywordAarray.Add(new MarkdownSyntaxKeyword(@"^#[^#]*?$", Color.FromArgb(obj.ForeColor_Headlines[1]), Color.FromArgb(obj.BackColor_Headlines[1])));
-			_MarkdownSyntaxKeywordAarray.Add(new MarkdownSyntaxKeyword(@"^.*\n=+$", Color.FromArgb(obj.ForeColor_Headlines[1]), Color.FromArgb(obj.BackColor_Headlines[1])));
-			//見出し２ ( Header 2 )
-			_MarkdownSyntaxKeywordAarray.Add(new MarkdownSyntaxKeyword(@"^##[^#]*?$", Color.FromArgb(obj.ForeColor_Headlines[2]), Color.FromArgb(obj.BackColor_Headlines[2])));
-			//見出し３ ( Header 3 )
-			_MarkdownSyntaxKeywordAarray.Add(new MarkdownSyntaxKeyword(@"^###[^#]*?$", Color.FromArgb(obj.ForeColor_Headlines[3]), Color.FromArgb(obj.BackColor_Headlines[3])));
-			//見出し４ ( Header 4 )
-			_MarkdownSyntaxKeywordAarray.Add(new MarkdownSyntaxKeyword(@"^####[^#]*?$", Color.FromArgb(obj.ForeColor_Headlines[4]), Color.FromArgb(obj.BackColor_Headlines[4])));
-			//見出し５ ( Header 5 )
-			_MarkdownSyntaxKeywordAarray.Add(new MarkdownSyntaxKeyword(@"^#####[^#]*?$", Color.FromArgb(obj.ForeColor_Headlines[5]), Color.FromArgb(obj.BackColor_Headlines[5])));
-			//見出し６ ( Header 6 )
-			_MarkdownSyntaxKeywordAarray.Add(new MarkdownSyntaxKeyword(@"^#####[^#]*?$", Color.FromArgb(obj.ForeColor_Headlines[6]), Color.FromArgb(obj.BackColor_Headlines[6])));
-			//引用 ( Brockquote )
-			_MarkdownSyntaxKeywordAarray.Add(new MarkdownSyntaxKeyword(@"^>.*$", Color.FromArgb(obj.ForeColor_Blockquotes), Color.FromArgb(obj.BackColor_Blockquotes)));
-			//リスト ( Lists )
-			_MarkdownSyntaxKeywordAarray.Add(new MarkdownSyntaxKeyword(@"^ {0,3}\*[ \t]+.*$|^ {0,3}\+[ \t]+.*$|^ {0,3}-[ \t]+.*$|^ {0,3}[0-9]+\.[ \t]+.*$", Color.FromArgb(obj.ForeColor_Lists), Color.FromArgb(obj.BackColor_Lists)));
-			//コードブロック ( Code blocks )
-			_MarkdownSyntaxKeywordAarray.Add(new MarkdownSyntaxKeyword(@"^ {4,}$|^\t{1,}$", Color.FromArgb(obj.ForeColor_CodeBlocks), Color.FromArgb(obj.BackColor_CodeBlocks)));
-			//罫線 ( Horizontal )
-			string horisontal_regex = @"^(\* ){3,}$|^\*.$|^(- ){3,}|^-{3,}$|^(_ ){3,}$|^_{3,}$";
-			_MarkdownSyntaxKeywordAarray.Add(new MarkdownSyntaxKeyword(horisontal_regex, Color.FromArgb(obj.ForeColor_Horizontal), Color.FromArgb(obj.BackColor_Horizontal)));
-			//「見出し２」だけは罫線よりも後に
-			// Parse "Header 2" after "Horizontal" 
-			_MarkdownSyntaxKeywordAarray.Add(new MarkdownSyntaxKeyword(@"^.+\n-+$", Color.FromArgb(obj.ForeColor_Headlines[2]), Color.FromArgb(obj.BackColor_Headlines[2])));
-			//リンク ( Link )
-			// [an example](http://example.com/ "Title") 
-			_MarkdownSyntaxKeywordAarray.Add(new MarkdownSyntaxKeyword(@"\[.*\]\((https?|ftp)(:\/\/[-_.!~*\'()a-zA-Z0-9;\/?:\@&=+\$,%#]+)[\t{1,}| {1,}]"".*""\)", Color.FromArgb(obj.ForeColor_Links), Color.FromArgb(obj.BackColor_Links)));
-			// [This link](http://example.net/)
-			_MarkdownSyntaxKeywordAarray.Add(new MarkdownSyntaxKeyword(@"\[.*\]\((https?|ftp)(:\/\/[-_.!~*\'()a-zA-Z0-9;\/?:\@&=+\$,%#]+)\)", Color.FromArgb(obj.ForeColor_Links), Color.FromArgb(obj.BackColor_Links)));
-			// [an example][id] 
-			// [an example] [id]
-			_MarkdownSyntaxKeywordAarray.Add(new MarkdownSyntaxKeyword(@"\[.*\]\((https?|ftp)(:\/\/[-_.!~*\'()a-zA-Z0-9;\/?:\@&=+\$,%#]+)\)", Color.FromArgb(obj.ForeColor_Links), Color.FromArgb(obj.BackColor_Links)));
-			// [id]: http://example.com/  "Optional Title Here"
-			_MarkdownSyntaxKeywordAarray.Add(new MarkdownSyntaxKeyword(@"\[.*\]:[\t{1,}| {1,}](https?|ftp)(:\/\/[-_.!~*\'()a-zA-Z0-9;\/?:\@&=+\$,%#]+)[\t{1,}| {1,}]"".*""", Color.FromArgb(obj.ForeColor_Links), Color.FromArgb(obj.BackColor_Links)));
-			//強調（em, em, strong, strong）
-			_MarkdownSyntaxKeywordAarray.Add(new MarkdownSyntaxKeyword(@"\*.*\*|_.*_|\*\*.*\*\*|__.*__", Color.FromArgb(obj.ForeColor_Emphasis), Color.FromArgb(obj.BackColor_Emphasis)));
-			//ソースコード ( Source code )
-			_MarkdownSyntaxKeywordAarray.Add(new MarkdownSyntaxKeyword(@"`.*`", Color.FromArgb(obj.ForeColor_Code), Color.FromArgb(obj.BackColor_Emphasis)));
-			//画像 ( Image )
-			_MarkdownSyntaxKeywordAarray.Add(new MarkdownSyntaxKeyword(@"!\[.*\]\(.*\)|!\[.*\]\[.*\]|\[.*\]: .*"".*""", Color.FromArgb(obj.ForeColor_Images), Color.FromArgb(obj.BackColor_Emphasis)));
-			//自動リンク（メールアドレスとURL） ( Auto Links )
-			_MarkdownSyntaxKeywordAarray.Add(new MarkdownSyntaxKeyword(@"<(https?|ftp)(:\/\/[-_.!~*\'()a-zA-Z0-9;\/?:\@&=+\$,%#]+)>", Color.FromArgb(obj.ForeColor_Links), Color.FromArgb(obj.BackColor_Links)));
-			string mail_regex = @"<(?:(?:(?:(?:[a-zA-Z0-9_!#\$\%&'*+/=?\^`{}~|\-]+)(?:\.(?:[a-zA-Z0-9_!#\$\%&'*+/=?\^`{}~|\-]+))*)|(?:""(?:\\[^\r\n]|[^\\""])*"")))\@(?:(?:(?:(?:[a-zA-Z0-9_!#\$\%&'*+/=?\^`{}~|\-]+)(?:\.(?:[a-zA-Z0-9_!#\$\%&'*+/=?\^`{}~|\-]+))*)|(?:\[(?:\\\S|[\x21-\x5a\x5e-\x7e])*\])))>";
-			_MarkdownSyntaxKeywordAarray.Add(new MarkdownSyntaxKeyword(mail_regex, Color.FromArgb(obj.ForeColor_Links), Color.FromArgb(obj.BackColor_Links)));
-			//コメントアウト（複数行含めたコメント全部）( Comment out )
-			_MarkdownSyntaxKeywordAarray.Add(new MarkdownSyntaxKeyword(@"<!--((?:.|\n)+)-->", Color.FromArgb(obj.ForeColor_Comments), Color.FromArgb(obj.BackColor_Comments)));
-
-			//-----------------------------------
-			// Markdown "Extra" SyntaxHighlighter
-			//-----------------------------------
-			if (MarkDownSharpEditor.AppSettings.Instance.fMarkdownExtraMode == true)
-			{
-				//HTMLブロック内のMarkdown記法（Markdown Inside HTML Blocks）
-				_MarkdownSyntaxKeywordAarray.Add(new MarkdownSyntaxKeyword("\\s*markdown\\s*=\\s*(?>([\"\'])(.*?)\\1|([^\\s>]*))()", Color.FromArgb(obj.ForeColor_MarkdownInsideHTMLBlocks), Color.FromArgb(obj.BackColor_MarkdownInsideHTMLBlocks)));
-				_MarkdownSyntaxKeywordAarray.Add(new MarkdownSyntaxKeyword("(</?[\\w:$]+(?:(?=[\\s\"\'/a-zA-Z0-9])(?>\".*?\"|\'.*?\'|.+?)*?)?>|<!--.*?-->|<\\?.*?\\?>|<%.*?%>|<!\\[CDATA\\[.*?\\]\\]>)", Color.FromArgb(obj.ForeColor_MarkdownInsideHTMLBlocks), Color.FromArgb(obj.BackColor_MarkdownInsideHTMLBlocks)));
-				//特殊な属性 ( Special Attributes )
-				_MarkdownSyntaxKeywordAarray.Add(new MarkdownSyntaxKeyword("(^.+?)(?:[ ]+.+?)?[ ]*\n(=+|-+)[ ]*\n+", Color.FromArgb(obj.ForeColor_SpecialAttributes), Color.FromArgb(obj.BackColor_SpecialAttributes)));
-				_MarkdownSyntaxKeywordAarray.Add(new MarkdownSyntaxKeyword("^(\\#{1,6})[ ]*(.+?)[ ]*\\#*(?:[ ]+.+?)?[ ]*\n+", Color.FromArgb(obj.ForeColor_SpecialAttributes), Color.FromArgb(obj.BackColor_SpecialAttributes)));
-				//コードブロック区切り（Fenced Code Blocks）
-				_MarkdownSyntaxKeywordAarray.Add(new MarkdownSyntaxKeyword("(?:\\n|\\A)(~{3,})[ ]*(?:\\.?([-_:a-zA-Z0-9]+)|\\{.+?\\})?[ ]*\\n((?>(?!\\1[ ]*\\n).*\\n+)+)\\1[ ]*\\n", Color.FromArgb(obj.ForeColor_FencedCodeBlocks), Color.FromArgb(obj.BackColor_FencedCodeBlocks)));
-				//表組み ( Tables )
-				_MarkdownSyntaxKeywordAarray.Add(new MarkdownSyntaxKeyword("^[ ]{0,2}[|](.+)\\n[ ]{0,2}[|]([ ]*[-:]+[-| :]*)\\n((?:[ ]*[|].*\\n)*)(?=\\n|\\Z)", Color.FromArgb(obj.ForeColor_Tables), Color.FromArgb(obj.BackColor_Tables)));
-				_MarkdownSyntaxKeywordAarray.Add(new MarkdownSyntaxKeyword("^[ ]{0,2}(\\S.*[|].*)\\n[ ]{0,2}([-:]+[ ]*[|][-| :]*)\\n((?:.*[|].*\\n)*)(?=\\n|\\Z)", Color.FromArgb(obj.ForeColor_Tables), Color.FromArgb(obj.BackColor_Tables)));
-				//定義リスト ( Definition Lists )
-				_MarkdownSyntaxKeywordAarray.Add(new MarkdownSyntaxKeyword("(?>\\A\\n?|(?<=\n\n))(?>(([ ]{0,}((?>.*\\S.*\\n)+)\\n?[ ]{0,}:[ ]+)(?s:.+?)(\\z|\\n{2,}(?=\\S)(?![ ]{0,}(?: \\S.*\\n )+?\\n?[ ]{0,}:[ ]+)(?![ ]{0,}:[ ]+))))", Color.FromArgb(obj.ForeColor_DefinitionLists), Color.FromArgb(obj.BackColor_DefinitionLists)));
-				//脚注 ( Footnotes )
-				_MarkdownSyntaxKeywordAarray.Add(new MarkdownSyntaxKeyword("^[ ]{0,}\\[\\^(.+?)\\][ ]?:[ ]*\n?((?:.+|\n(?!\\[\\^.+?\\]:\\s)(?!\\n+[ ]{0,3}\\S))*)", Color.FromArgb(obj.ForeColor_Footnotes), Color.FromArgb(obj.BackColor_Footnotes)));
-				//省略表記 ( Abbreviations )
-				_MarkdownSyntaxKeywordAarray.Add(new MarkdownSyntaxKeyword("^[ ]{0,}\\*\\[(.+?)\\][ ]?:(.*)", Color.FromArgb(obj.ForeColor_Abbreviations), Color.FromArgb(obj.BackColor_Abbreviations)));
-				//強調表示 : むしろダブルコーテーション内は解除する
-				//Emphasis : Rather than remove the syntaxHighlighter of Emphasis within the double quotes
-				_MarkdownSyntaxKeywordAarray.Add(new MarkdownSyntaxKeyword("\".*?\"", Color.FromArgb(obj.ForeColor_MainText), Color.FromArgb(obj.BackColor_MainText)));
-				//バックスラッシュエスケープ ( Backslash Escapes )
-				_MarkdownSyntaxKeywordAarray.Add(new MarkdownSyntaxKeyword(@"(\\:)|(\\|)", Color.FromArgb(obj.ForeColor_BackslashEscapes), Color.FromArgb(obj.BackColor_BackslashEscapes)));
-			}
-
-		}
 
 
 		//======================================================================
@@ -2666,7 +2572,7 @@ namespace MarkDownSharpEditor
 			frm3.ShowDialog();
 			frm3.Dispose();
 
-			RefreshSyntaxHightlighterKeyword();	 //キーワードリストの更新
+			_MarkdownSyntaxKeywordAarray = MarkdownSyntaxKeyword.CreateKeywordList();	 //キーワードリストの更新
 			if (backgroundWorker2.IsBusy == false)
 			{
 				//SyntaxHightlighter on BackgroundWorker

--- a/MarkDownSharpEditor/Form1.cs
+++ b/MarkDownSharpEditor/Form1.cs
@@ -719,10 +719,11 @@ namespace MarkDownSharpEditor
 			//webBrowser1.Navigate("about:blank");
 			//クリック音対策
 			//Constraint click sounds
-			webBrowser1.Document.OpenNew(true);
-			webBrowser1.Document.Write("");
-			//WebBrowserClickSoundON();
-
+			if (webBrowser1.Document != null)
+			{
+				webBrowser1.Document.OpenNew(true);
+				webBrowser1.Document.Write("");
+			}
 		}
 
 		//-----------------------------------
@@ -1343,7 +1344,11 @@ namespace MarkDownSharpEditor
 					//Memorize scroll positions
 					HtmlDocument doc = webBrowser1.Document;
 					Point scrollpos = new Point(0, 0);
-					if (doc != null)
+					if (doc == null)
+					{
+						webBrowser1.Navigate("about:blank");
+					}
+					else
 					{
 						IHTMLDocument3 doc3 = (IHTMLDocument3)webBrowser1.Document.DomDocument;
 						IHTMLElement2 elm = (IHTMLElement2)doc3.documentElement;

--- a/MarkDownSharpEditor/MarkdownSyntaxKeyword.cs
+++ b/MarkDownSharpEditor/MarkdownSyntaxKeyword.cs
@@ -2,6 +2,7 @@
 using System.Collections.Generic;
 using System.Linq;
 using System.Text;
+using System.Text.RegularExpressions;
 using System.Drawing;
 
 namespace MarkDownSharpEditor
@@ -9,6 +10,97 @@ namespace MarkDownSharpEditor
 	//MarkdownキーワードSyntaxHighlighterクラス
 	class MarkdownSyntaxKeyword
 	{
+		private const string mail_regex = @"<(?:(?:(?:(?:[a-zA-Z0-9_!#\$\%&'*+/=?\^`{}~|\-]+)(?:\.(?:[a-zA-Z0-9_!#\$\%&'*+/=?\^`{}~|\-]+))*)|(?:""(?:\\[^\r\n]|[^\\""])*"")))\@(?:(?:(?:(?:[a-zA-Z0-9_!#\$\%&'*+/=?\^`{}~|\-]+)(?:\.(?:[a-zA-Z0-9_!#\$\%&'*+/=?\^`{}~|\-]+))*)|(?:\[(?:\\\S|[\x21-\x5a\x5e-\x7e])*\])))>";
+		private const string horisontal_regex = @"^(\* ){3,}$|^\*.$|^(- ){3,}|^-{3,}$|^(_ ){3,}$|^_{3,}$";
+
+		//----------------------------------------------------------------------
+		// シンタックス・ハイライター（Regex）のキーワード更新
+		// Refresh regular expression of syntax hightlighter keyword
+		//----------------------------------------------------------------------
+		public static List<MarkdownSyntaxKeyword> CreateKeywordList()
+		{
+			var obj = MarkDownSharpEditor.AppSettings.Instance;
+			var keywords = new List<MarkdownSyntaxKeyword> {
+				//強制ブレーク ( Line break )
+				new MarkdownSyntaxKeyword(@"  $", Color.FromArgb(obj.ForeColor_LineBreak), Color.FromArgb(obj.BackColor_LineBreak)),
+				//見出し１ ( Header 1 )
+				new MarkdownSyntaxKeyword(@"^#[^#]*?$", Color.FromArgb(obj.ForeColor_Headlines[1]), Color.FromArgb(obj.BackColor_Headlines[1])),
+				new MarkdownSyntaxKeyword(@"^.*\n=+$", Color.FromArgb(obj.ForeColor_Headlines[1]), Color.FromArgb(obj.BackColor_Headlines[1])),
+				//見出し２ ( Header 2 )
+				new MarkdownSyntaxKeyword(@"^##[^#]*?$", Color.FromArgb(obj.ForeColor_Headlines[2]), Color.FromArgb(obj.BackColor_Headlines[2])),
+				//見出し３ ( Header 3 )
+				new MarkdownSyntaxKeyword(@"^###[^#]*?$", Color.FromArgb(obj.ForeColor_Headlines[3]), Color.FromArgb(obj.BackColor_Headlines[3])),
+				//見出し４ ( Header 4 )
+				new MarkdownSyntaxKeyword(@"^####[^#]*?$", Color.FromArgb(obj.ForeColor_Headlines[4]), Color.FromArgb(obj.BackColor_Headlines[4])),
+				//見出し５ ( Header 5 )
+				new MarkdownSyntaxKeyword(@"^#####[^#]*?$", Color.FromArgb(obj.ForeColor_Headlines[5]), Color.FromArgb(obj.BackColor_Headlines[5])),
+				//見出し６ ( Header 6 )
+				new MarkdownSyntaxKeyword(@"^#####[^#]*?$", Color.FromArgb(obj.ForeColor_Headlines[6]), Color.FromArgb(obj.BackColor_Headlines[6])),
+				//引用 ( Brockquote )
+				new MarkdownSyntaxKeyword(@"^>.*$", Color.FromArgb(obj.ForeColor_Blockquotes), Color.FromArgb(obj.BackColor_Blockquotes)),
+				//リスト ( Lists )
+				new MarkdownSyntaxKeyword(@"^ {0,3}\*[ \t]+.*$|^ {0,3}\+[ \t]+.*$|^ {0,3}-[ \t]+.*$|^ {0,3}[0-9]+\.[ \t]+.*$", Color.FromArgb(obj.ForeColor_Lists), Color.FromArgb(obj.BackColor_Lists)),
+				//コードブロック ( Code blocks )
+				new MarkdownSyntaxKeyword(@"^ {4,}$|^\t{1,}$", Color.FromArgb(obj.ForeColor_CodeBlocks), Color.FromArgb(obj.BackColor_CodeBlocks)),
+				//罫線 ( Horizontal )
+				new MarkdownSyntaxKeyword(horisontal_regex, Color.FromArgb(obj.ForeColor_Horizontal), Color.FromArgb(obj.BackColor_Horizontal)),
+				//「見出し２」だけは罫線よりも後に
+				// Parse "Header 2" after "Horizontal" 
+				new MarkdownSyntaxKeyword(@"^.+\n-+$", Color.FromArgb(obj.ForeColor_Headlines[2]), Color.FromArgb(obj.BackColor_Headlines[2])),
+				//リンク ( Link )
+				// [an example](http://example.com/ "Title") 
+				new MarkdownSyntaxKeyword(@"\[.*\]\((https?|ftp)(:\/\/[-_.!~*\'()a-zA-Z0-9;\/?:\@&=+\$,%#]+)[\t{1,}| {1,}]"".*""\)", Color.FromArgb(obj.ForeColor_Links), Color.FromArgb(obj.BackColor_Links)),
+				// [This link](http://example.net/)
+				new MarkdownSyntaxKeyword(@"\[.*\]\((https?|ftp)(:\/\/[-_.!~*\'()a-zA-Z0-9;\/?:\@&=+\$,%#]+)\)", Color.FromArgb(obj.ForeColor_Links), Color.FromArgb(obj.BackColor_Links)),
+				// [an example][id] 
+				// [an example] [id]
+				new MarkdownSyntaxKeyword(@"\[.*\]\((https?|ftp)(:\/\/[-_.!~*\'()a-zA-Z0-9;\/?:\@&=+\$,%#]+)\)", Color.FromArgb(obj.ForeColor_Links), Color.FromArgb(obj.BackColor_Links)),
+				// [id]: http://example.com/  "Optional Title Here"
+				new MarkdownSyntaxKeyword(@"\[.*\]:[\t{1,}| {1,}](https?|ftp)(:\/\/[-_.!~*\'()a-zA-Z0-9;\/?:\@&=+\$,%#]+)[\t{1,}| {1,}]"".*""", Color.FromArgb(obj.ForeColor_Links), Color.FromArgb(obj.BackColor_Links)),
+				//強調（em, em, strong, strong）
+				new MarkdownSyntaxKeyword(@"\*.*\*|_.*_|\*\*.*\*\*|__.*__", Color.FromArgb(obj.ForeColor_Emphasis), Color.FromArgb(obj.BackColor_Emphasis)),
+				//ソースコード ( Source code )
+				new MarkdownSyntaxKeyword(@"`.*`", Color.FromArgb(obj.ForeColor_Code), Color.FromArgb(obj.BackColor_Emphasis)),
+				//画像 ( Image )
+				new MarkdownSyntaxKeyword(@"!\[.*\]\(.*\)|!\[.*\]\[.*\]|\[.*\]: .*"".*""", Color.FromArgb(obj.ForeColor_Images), Color.FromArgb(obj.BackColor_Emphasis)),
+				//自動リンク（メールアドレスとURL） ( Auto Links )
+				new MarkdownSyntaxKeyword(@"<(https?|ftp)(:\/\/[-_.!~*\'()a-zA-Z0-9;\/?:\@&=+\$,%#]+)>", Color.FromArgb(obj.ForeColor_Links), Color.FromArgb(obj.BackColor_Links)),
+				new MarkdownSyntaxKeyword(mail_regex, Color.FromArgb(obj.ForeColor_Links), Color.FromArgb(obj.BackColor_Links)),
+				//コメントアウト（複数行含めたコメント全部）( Comment out )
+				new MarkdownSyntaxKeyword(@"<!--((?:.|\n)+)-->", Color.FromArgb(obj.ForeColor_Comments), Color.FromArgb(obj.BackColor_Comments))
+			};
+
+			//-----------------------------------
+			// Markdown "Extra" SyntaxHighlighter
+			//-----------------------------------
+			if (MarkDownSharpEditor.AppSettings.Instance.fMarkdownExtraMode == true)
+			{
+				//HTMLブロック内のMarkdown記法（Markdown Inside HTML Blocks）
+				keywords.Add(new MarkdownSyntaxKeyword("\\s*markdown\\s*=\\s*(?>([\"\'])(.*?)\\1|([^\\s>]*))()", Color.FromArgb(obj.ForeColor_MarkdownInsideHTMLBlocks), Color.FromArgb(obj.BackColor_MarkdownInsideHTMLBlocks)));
+				keywords.Add(new MarkdownSyntaxKeyword("(</?[\\w:$]+(?:(?=[\\s\"\'/a-zA-Z0-9])(?>\".*?\"|\'.*?\'|.+?)*?)?>|<!--.*?-->|<\\?.*?\\?>|<%.*?%>|<!\\[CDATA\\[.*?\\]\\]>)", Color.FromArgb(obj.ForeColor_MarkdownInsideHTMLBlocks), Color.FromArgb(obj.BackColor_MarkdownInsideHTMLBlocks)));
+				//特殊な属性 ( Special Attributes )
+				keywords.Add(new MarkdownSyntaxKeyword("(^.+?)(?:[ ]+.+?)?[ ]*\n(=+|-+)[ ]*\n+", Color.FromArgb(obj.ForeColor_SpecialAttributes), Color.FromArgb(obj.BackColor_SpecialAttributes)));
+				keywords.Add(new MarkdownSyntaxKeyword("^(\\#{1,6})[ ]*(.+?)[ ]*\\#*(?:[ ]+.+?)?[ ]*\n+", Color.FromArgb(obj.ForeColor_SpecialAttributes), Color.FromArgb(obj.BackColor_SpecialAttributes)));
+				//コードブロック区切り（Fenced Code Blocks）
+				keywords.Add(new MarkdownSyntaxKeyword("(?:\\n|\\A)(~{3,})[ ]*(?:\\.?([-_:a-zA-Z0-9]+)|\\{.+?\\})?[ ]*\\n((?>(?!\\1[ ]*\\n).*\\n+)+)\\1[ ]*\\n", Color.FromArgb(obj.ForeColor_FencedCodeBlocks), Color.FromArgb(obj.BackColor_FencedCodeBlocks)));
+				//表組み ( Tables )
+				keywords.Add(new MarkdownSyntaxKeyword("^[ ]{0,2}[|](.+)\\n[ ]{0,2}[|]([ ]*[-:]+[-| :]*)\\n((?:[ ]*[|].*\\n)*)(?=\\n|\\Z)", Color.FromArgb(obj.ForeColor_Tables), Color.FromArgb(obj.BackColor_Tables)));
+				keywords.Add(new MarkdownSyntaxKeyword("^[ ]{0,2}(\\S.*[|].*)\\n[ ]{0,2}([-:]+[ ]*[|][-| :]*)\\n((?:.*[|].*\\n)*)(?=\\n|\\Z)", Color.FromArgb(obj.ForeColor_Tables), Color.FromArgb(obj.BackColor_Tables)));
+				//定義リスト ( Definition Lists )
+				keywords.Add(new MarkdownSyntaxKeyword("(?>\\A\\n?|(?<=\n\n))(?>(([ ]{0,}((?>.*\\S.*\\n)+)\\n?[ ]{0,}:[ ]+)(?s:.+?)(\\z|\\n{2,}(?=\\S)(?![ ]{0,}(?: \\S.*\\n )+?\\n?[ ]{0,}:[ ]+)(?![ ]{0,}:[ ]+))))", Color.FromArgb(obj.ForeColor_DefinitionLists), Color.FromArgb(obj.BackColor_DefinitionLists)));
+				//脚注 ( Footnotes )
+				keywords.Add(new MarkdownSyntaxKeyword("^[ ]{0,}\\[\\^(.+?)\\][ ]?:[ ]*\n?((?:.+|\n(?!\\[\\^.+?\\]:\\s)(?!\\n+[ ]{0,3}\\S))*)", Color.FromArgb(obj.ForeColor_Footnotes), Color.FromArgb(obj.BackColor_Footnotes)));
+				//省略表記 ( Abbreviations )
+				keywords.Add(new MarkdownSyntaxKeyword("^[ ]{0,}\\*\\[(.+?)\\][ ]?:(.*)", Color.FromArgb(obj.ForeColor_Abbreviations), Color.FromArgb(obj.BackColor_Abbreviations)));
+				//強調表示 : むしろダブルコーテーション内は解除する
+				//Emphasis : Rather than remove the syntaxHighlighter of Emphasis within the double quotes
+				keywords.Add(new MarkdownSyntaxKeyword("\".*?\"", Color.FromArgb(obj.ForeColor_MainText), Color.FromArgb(obj.BackColor_MainText)));
+				//バックスラッシュエスケープ ( Backslash Escapes )
+				keywords.Add(new MarkdownSyntaxKeyword(@"(\\:)|(\\|)", Color.FromArgb(obj.ForeColor_BackslashEscapes), Color.FromArgb(obj.BackColor_BackslashEscapes)));
+			}
+			return keywords;
+		}
+
 		private string _RegText;
 		private Color _ForeColor = Color.Black;
 		private Color _BackColor = Color.White;
@@ -16,6 +108,7 @@ namespace MarkDownSharpEditor
 		public MarkdownSyntaxKeyword(string reg, Color f, Color b)
 		{
 			_RegText = reg;
+			Regex = new Regex(RegText, RegexOptions.Multiline | RegexOptions.IgnoreCase | RegexOptions.Compiled);
 			_ForeColor = f;
 			_BackColor = b;
 		}
@@ -24,6 +117,7 @@ namespace MarkDownSharpEditor
 			get { return _RegText; }
 			set { _RegText = RegText; }
 		}
+		public Regex Regex { get; private set; }
 		public Color ForeColor
 		{
 			get { return _ForeColor; }


### PR DESCRIPTION
.gitattribuutes に "\* text=auto" とあるのに、リポジトリに CRLF のファイルが入っているような気がします。
clone するだけで変更ファイルが出たり、一部を編集しただけで全体が差分表示されたりします。※

そもそも MarkDownSharpEditor は、Windows で開発して Windows で動かすツールですので、
LF環境からコミットする人はいないと判断し、改行コード変換をしないように変更しました。

※　こちらの環境のせいかもしれないので自信は無いのですが。
