### PR TITLE
Change the way of syntax highlighter result passing from by field to eventArgs.Result

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,5 +1,5 @@
 # Auto detect text files and perform LF normalization
-* text=auto
+* -text
 
 # Custom for Visual Studio
 *.cs     diff=csharp


### PR DESCRIPTION
blogでご紹介なさっているBackgroundWorkerを使ったハイライト処理ですが、
結果の受け渡しがおかしかったので直しました。

前回の.gitattributesの修正も含んでしまっていますが、ご不用でしたらcherry-pickしてください。
