### PR TITLE
Fix NullReferenceException error on opening/closing Untitled

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,5 +1,5 @@
 # Auto detect text files and perform LF normalization
-* text=auto
+* -text
 
 # Custom for Visual Studio
 *.cs     diff=csharp

--- a/MarkDownSharpEditor/Form1.cs
+++ b/MarkDownSharpEditor/Form1.cs
@@ -719,10 +719,11 @@ namespace MarkDownSharpEditor
 			//webBrowser1.Navigate("about:blank");
 			//クリック音対策
 			//Constraint click sounds
-			webBrowser1.Document.OpenNew(true);
-			webBrowser1.Document.Write("");
-			//WebBrowserClickSoundON();
-
+			if (webBrowser1.Document != null)
+			{
+				webBrowser1.Document.OpenNew(true);
+				webBrowser1.Document.Write("");
+			}
 		}
 
 		//-----------------------------------
@@ -1343,7 +1344,11 @@ namespace MarkDownSharpEditor
 					//Memorize scroll positions
 					HtmlDocument doc = webBrowser1.Document;
 					Point scrollpos = new Point(0, 0);
-					if (doc != null)
+					if (doc == null)
+					{
+						webBrowser1.Navigate("about:blank");
+					}
+					else
 					{
 						IHTMLDocument3 doc3 = (IHTMLDocument3)webBrowser1.Document.DomDocument;
 						IHTMLElement2 elm = (IHTMLElement2)doc3.documentElement;


### PR DESCRIPTION
https://github.com/hibara/MarkDownSharpEditor/pull/16 と同様です。
そもそも新しいドキュメントを作成した時にNavigateしたほうがいいのかもしれませんが、取り急ぎWorkaroundとして。

こちらも#25と同じく、前回の.gitattributesの修正も含んでしまっていますが、ご不用でしたらcherry-pickしてください。
