### PR TITLE
Fix regex pattern for "Backslash escapes" 

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,5 +1,5 @@
 # Auto detect text files and perform LF normalization
-* text=auto
+* -text
 
 # Custom for Visual Studio
 *.cs     diff=csharp

--- a/MarkDownSharpEditor/Form1.cs
+++ b/MarkDownSharpEditor/Form1.cs
@@ -1925,7 +1925,7 @@ namespace MarkDownSharpEditor
 				//Emphasis : Rather than remove the syntaxHighlighter of Emphasis within the double quotes
 				_MarkdownSyntaxKeywordAarray.Add(new MarkdownSyntaxKeyword("\".*?\"", Color.FromArgb(obj.ForeColor_MainText), Color.FromArgb(obj.BackColor_MainText)));
 				//バックスラッシュエスケープ ( Backslash Escapes )
-				_MarkdownSyntaxKeywordAarray.Add(new MarkdownSyntaxKeyword(@"(\\:)|(\\|)", Color.FromArgb(obj.ForeColor_BackslashEscapes), Color.FromArgb(obj.BackColor_BackslashEscapes)));
+				_MarkdownSyntaxKeywordAarray.Add(new MarkdownSyntaxKeyword(@"\\:|\\\|", Color.FromArgb(obj.ForeColor_BackslashEscapes), Color.FromArgb(obj.BackColor_BackslashEscapes)));
 			}
 
 		}

--- a/MarkDownSharpEditor/Form1.cs
+++ b/MarkDownSharpEditor/Form1.cs
@@ -48,7 +48,7 @@ namespace MarkDownSharpEditor
 		private Encoding _EditingFileEncoding = Encoding.UTF8;             //編集中MDファイルの文字エンコーディング ( Character encoding of MD file editing )
 
 		private bool _fConstraintChange = true;	                           //更新状態の抑制 ( Constraint changing flag )
-		private ArrayList _MarkdownSyntaxKeywordAarray = new ArrayList();  // Array of MarkdownSyntaxKeyword Class
+		private List<MarkdownSyntaxKeyword> _MarkdownSyntaxKeywordAarray = new List<MarkdownSyntaxKeyword>();  // Array of MarkdownSyntaxKeyword Class
 
 		private ArrayList _SyntaxArrayList = new ArrayList();
 
@@ -159,7 +159,7 @@ namespace MarkDownSharpEditor
 
 			//エディターのシンタックスハイライター設定の反映
 			//Syntax highlighter of editor window is enabled 
-			RefreshSyntaxHightlighterKeyword();
+			_MarkdownSyntaxKeywordAarray = MarkdownSyntaxKeyword.CreateKeywordList();
 
 			//-----------------------------------
 			//選択中のエンコーディングを表示
@@ -1836,101 +1836,6 @@ namespace MarkDownSharpEditor
 			return new string(destChars);
 		}
 
-
-		//----------------------------------------------------------------------
-		// シンタックス・ハイライター（Regex）のキーワード更新
-		// Refresh regular expression of syntax hightlighter keyword
-		//----------------------------------------------------------------------
-		private void RefreshSyntaxHightlighterKeyword()
-		{
-			var obj = MarkDownSharpEditor.AppSettings.Instance;
-			_MarkdownSyntaxKeywordAarray.Clear();
-
-			//-----------------------------------
-			// Markdown SyntaxHighlighter
-			//-----------------------------------
-			//強制ブレーク ( Line break )
-			_MarkdownSyntaxKeywordAarray.Add(new MarkdownSyntaxKeyword(@"  $", Color.FromArgb(obj.ForeColor_LineBreak), Color.FromArgb(obj.BackColor_LineBreak)));
-			//見出し１ ( Header 1 )
-			_MarkdownSyntaxKeywordAarray.Add(new MarkdownSyntaxKeyword(@"^#[^#]*?$", Color.FromArgb(obj.ForeColor_Headlines[1]), Color.FromArgb(obj.BackColor_Headlines[1])));
-			_MarkdownSyntaxKeywordAarray.Add(new MarkdownSyntaxKeyword(@"^.*\n=+$", Color.FromArgb(obj.ForeColor_Headlines[1]), Color.FromArgb(obj.BackColor_Headlines[1])));
-			//見出し２ ( Header 2 )
-			_MarkdownSyntaxKeywordAarray.Add(new MarkdownSyntaxKeyword(@"^##[^#]*?$", Color.FromArgb(obj.ForeColor_Headlines[2]), Color.FromArgb(obj.BackColor_Headlines[2])));
-			//見出し３ ( Header 3 )
-			_MarkdownSyntaxKeywordAarray.Add(new MarkdownSyntaxKeyword(@"^###[^#]*?$", Color.FromArgb(obj.ForeColor_Headlines[3]), Color.FromArgb(obj.BackColor_Headlines[3])));
-			//見出し４ ( Header 4 )
-			_MarkdownSyntaxKeywordAarray.Add(new MarkdownSyntaxKeyword(@"^####[^#]*?$", Color.FromArgb(obj.ForeColor_Headlines[4]), Color.FromArgb(obj.BackColor_Headlines[4])));
-			//見出し５ ( Header 5 )
-			_MarkdownSyntaxKeywordAarray.Add(new MarkdownSyntaxKeyword(@"^#####[^#]*?$", Color.FromArgb(obj.ForeColor_Headlines[5]), Color.FromArgb(obj.BackColor_Headlines[5])));
-			//見出し６ ( Header 6 )
-			_MarkdownSyntaxKeywordAarray.Add(new MarkdownSyntaxKeyword(@"^#####[^#]*?$", Color.FromArgb(obj.ForeColor_Headlines[6]), Color.FromArgb(obj.BackColor_Headlines[6])));
-			//引用 ( Brockquote )
-			_MarkdownSyntaxKeywordAarray.Add(new MarkdownSyntaxKeyword(@"^>.*$", Color.FromArgb(obj.ForeColor_Blockquotes), Color.FromArgb(obj.BackColor_Blockquotes)));
-			//リスト ( Lists )
-			_MarkdownSyntaxKeywordAarray.Add(new MarkdownSyntaxKeyword(@"^ {0,3}\*[ \t]+.*$|^ {0,3}\+[ \t]+.*$|^ {0,3}-[ \t]+.*$|^ {0,3}[0-9]+\.[ \t]+.*$", Color.FromArgb(obj.ForeColor_Lists), Color.FromArgb(obj.BackColor_Lists)));
-			//コードブロック ( Code blocks )
-			_MarkdownSyntaxKeywordAarray.Add(new MarkdownSyntaxKeyword(@"^ {4,}$|^\t{1,}$", Color.FromArgb(obj.ForeColor_CodeBlocks), Color.FromArgb(obj.BackColor_CodeBlocks)));
-			//罫線 ( Horizontal )
-			string horisontal_regex = @"^(\* ){3,}$|^\*.$|^(- ){3,}|^-{3,}$|^(_ ){3,}$|^_{3,}$";
-			_MarkdownSyntaxKeywordAarray.Add(new MarkdownSyntaxKeyword(horisontal_regex, Color.FromArgb(obj.ForeColor_Horizontal), Color.FromArgb(obj.BackColor_Horizontal)));
-			//「見出し２」だけは罫線よりも後に
-			// Parse "Header 2" after "Horizontal" 
-			_MarkdownSyntaxKeywordAarray.Add(new MarkdownSyntaxKeyword(@"^.+\n-+$", Color.FromArgb(obj.ForeColor_Headlines[2]), Color.FromArgb(obj.BackColor_Headlines[2])));
-			//リンク ( Link )
-			// [an example](http://example.com/ "Title") 
-			_MarkdownSyntaxKeywordAarray.Add(new MarkdownSyntaxKeyword(@"\[.*\]\((https?|ftp)(:\/\/[-_.!~*\'()a-zA-Z0-9;\/?:\@&=+\$,%#]+)[\t{1,}| {1,}]"".*""\)", Color.FromArgb(obj.ForeColor_Links), Color.FromArgb(obj.BackColor_Links)));
-			// [This link](http://example.net/)
-			_MarkdownSyntaxKeywordAarray.Add(new MarkdownSyntaxKeyword(@"\[.*\]\((https?|ftp)(:\/\/[-_.!~*\'()a-zA-Z0-9;\/?:\@&=+\$,%#]+)\)", Color.FromArgb(obj.ForeColor_Links), Color.FromArgb(obj.BackColor_Links)));
-			// [an example][id] 
-			// [an example] [id]
-			_MarkdownSyntaxKeywordAarray.Add(new MarkdownSyntaxKeyword(@"\[.*\]\((https?|ftp)(:\/\/[-_.!~*\'()a-zA-Z0-9;\/?:\@&=+\$,%#]+)\)", Color.FromArgb(obj.ForeColor_Links), Color.FromArgb(obj.BackColor_Links)));
-			// [id]: http://example.com/  "Optional Title Here"
-			_MarkdownSyntaxKeywordAarray.Add(new MarkdownSyntaxKeyword(@"\[.*\]:[\t{1,}| {1,}](https?|ftp)(:\/\/[-_.!~*\'()a-zA-Z0-9;\/?:\@&=+\$,%#]+)[\t{1,}| {1,}]"".*""", Color.FromArgb(obj.ForeColor_Links), Color.FromArgb(obj.BackColor_Links)));
-			//強調（em, em, strong, strong）
-			_MarkdownSyntaxKeywordAarray.Add(new MarkdownSyntaxKeyword(@"\*.*\*|_.*_|\*\*.*\*\*|__.*__", Color.FromArgb(obj.ForeColor_Emphasis), Color.FromArgb(obj.BackColor_Emphasis)));
-			//ソースコード ( Source code )
-			_MarkdownSyntaxKeywordAarray.Add(new MarkdownSyntaxKeyword(@"`.*`", Color.FromArgb(obj.ForeColor_Code), Color.FromArgb(obj.BackColor_Emphasis)));
-			//画像 ( Image )
-			_MarkdownSyntaxKeywordAarray.Add(new MarkdownSyntaxKeyword(@"!\[.*\]\(.*\)|!\[.*\]\[.*\]|\[.*\]: .*"".*""", Color.FromArgb(obj.ForeColor_Images), Color.FromArgb(obj.BackColor_Emphasis)));
-			//自動リンク（メールアドレスとURL） ( Auto Links )
-			_MarkdownSyntaxKeywordAarray.Add(new MarkdownSyntaxKeyword(@"<(https?|ftp)(:\/\/[-_.!~*\'()a-zA-Z0-9;\/?:\@&=+\$,%#]+)>", Color.FromArgb(obj.ForeColor_Links), Color.FromArgb(obj.BackColor_Links)));
-			string mail_regex = @"<(?:(?:(?:(?:[a-zA-Z0-9_!#\$\%&'*+/=?\^`{}~|\-]+)(?:\.(?:[a-zA-Z0-9_!#\$\%&'*+/=?\^`{}~|\-]+))*)|(?:""(?:\\[^\r\n]|[^\\""])*"")))\@(?:(?:(?:(?:[a-zA-Z0-9_!#\$\%&'*+/=?\^`{}~|\-]+)(?:\.(?:[a-zA-Z0-9_!#\$\%&'*+/=?\^`{}~|\-]+))*)|(?:\[(?:\\\S|[\x21-\x5a\x5e-\x7e])*\])))>";
-			_MarkdownSyntaxKeywordAarray.Add(new MarkdownSyntaxKeyword(mail_regex, Color.FromArgb(obj.ForeColor_Links), Color.FromArgb(obj.BackColor_Links)));
-			//コメントアウト（複数行含めたコメント全部）( Comment out )
-			_MarkdownSyntaxKeywordAarray.Add(new MarkdownSyntaxKeyword(@"<!--((?:.|\n)+)-->", Color.FromArgb(obj.ForeColor_Comments), Color.FromArgb(obj.BackColor_Comments)));
-
-			//-----------------------------------
-			// Markdown "Extra" SyntaxHighlighter
-			//-----------------------------------
-			if (MarkDownSharpEditor.AppSettings.Instance.fMarkdownExtraMode == true)
-			{
-				//HTMLブロック内のMarkdown記法（Markdown Inside HTML Blocks）
-				_MarkdownSyntaxKeywordAarray.Add(new MarkdownSyntaxKeyword("\\s*markdown\\s*=\\s*(?>([\"\'])(.*?)\\1|([^\\s>]*))()", Color.FromArgb(obj.ForeColor_MarkdownInsideHTMLBlocks), Color.FromArgb(obj.BackColor_MarkdownInsideHTMLBlocks)));
-				_MarkdownSyntaxKeywordAarray.Add(new MarkdownSyntaxKeyword("(</?[\\w:$]+(?:(?=[\\s\"\'/a-zA-Z0-9])(?>\".*?\"|\'.*?\'|.+?)*?)?>|<!--.*?-->|<\\?.*?\\?>|<%.*?%>|<!\\[CDATA\\[.*?\\]\\]>)", Color.FromArgb(obj.ForeColor_MarkdownInsideHTMLBlocks), Color.FromArgb(obj.BackColor_MarkdownInsideHTMLBlocks)));
-				//特殊な属性 ( Special Attributes )
-				_MarkdownSyntaxKeywordAarray.Add(new MarkdownSyntaxKeyword("(^.+?)(?:[ ]+.+?)?[ ]*\n(=+|-+)[ ]*\n+", Color.FromArgb(obj.ForeColor_SpecialAttributes), Color.FromArgb(obj.BackColor_SpecialAttributes)));
-				_MarkdownSyntaxKeywordAarray.Add(new MarkdownSyntaxKeyword("^(\\#{1,6})[ ]*(.+?)[ ]*\\#*(?:[ ]+.+?)?[ ]*\n+", Color.FromArgb(obj.ForeColor_SpecialAttributes), Color.FromArgb(obj.BackColor_SpecialAttributes)));
-				//コードブロック区切り（Fenced Code Blocks）
-				_MarkdownSyntaxKeywordAarray.Add(new MarkdownSyntaxKeyword("(?:\\n|\\A)(~{3,})[ ]*(?:\\.?([-_:a-zA-Z0-9]+)|\\{.+?\\})?[ ]*\\n((?>(?!\\1[ ]*\\n).*\\n+)+)\\1[ ]*\\n", Color.FromArgb(obj.ForeColor_FencedCodeBlocks), Color.FromArgb(obj.BackColor_FencedCodeBlocks)));
-				//表組み ( Tables )
-				_MarkdownSyntaxKeywordAarray.Add(new MarkdownSyntaxKeyword("^[ ]{0,2}[|](.+)\\n[ ]{0,2}[|]([ ]*[-:]+[-| :]*)\\n((?:[ ]*[|].*\\n)*)(?=\\n|\\Z)", Color.FromArgb(obj.ForeColor_Tables), Color.FromArgb(obj.BackColor_Tables)));
-				_MarkdownSyntaxKeywordAarray.Add(new MarkdownSyntaxKeyword("^[ ]{0,2}(\\S.*[|].*)\\n[ ]{0,2}([-:]+[ ]*[|][-| :]*)\\n((?:.*[|].*\\n)*)(?=\\n|\\Z)", Color.FromArgb(obj.ForeColor_Tables), Color.FromArgb(obj.BackColor_Tables)));
-				//定義リスト ( Definition Lists )
-				_MarkdownSyntaxKeywordAarray.Add(new MarkdownSyntaxKeyword("(?>\\A\\n?|(?<=\n\n))(?>(([ ]{0,}((?>.*\\S.*\\n)+)\\n?[ ]{0,}:[ ]+)(?s:.+?)(\\z|\\n{2,}(?=\\S)(?![ ]{0,}(?: \\S.*\\n )+?\\n?[ ]{0,}:[ ]+)(?![ ]{0,}:[ ]+))))", Color.FromArgb(obj.ForeColor_DefinitionLists), Color.FromArgb(obj.BackColor_DefinitionLists)));
-				//脚注 ( Footnotes )
-				_MarkdownSyntaxKeywordAarray.Add(new MarkdownSyntaxKeyword("^[ ]{0,}\\[\\^(.+?)\\][ ]?:[ ]*\n?((?:.+|\n(?!\\[\\^.+?\\]:\\s)(?!\\n+[ ]{0,3}\\S))*)", Color.FromArgb(obj.ForeColor_Footnotes), Color.FromArgb(obj.BackColor_Footnotes)));
-				//省略表記 ( Abbreviations )
-				_MarkdownSyntaxKeywordAarray.Add(new MarkdownSyntaxKeyword("^[ ]{0,}\\*\\[(.+?)\\][ ]?:(.*)", Color.FromArgb(obj.ForeColor_Abbreviations), Color.FromArgb(obj.BackColor_Abbreviations)));
-				//強調表示 : むしろダブルコーテーション内は解除する
-				//Emphasis : Rather than remove the syntaxHighlighter of Emphasis within the double quotes
-				_MarkdownSyntaxKeywordAarray.Add(new MarkdownSyntaxKeyword("\".*?\"", Color.FromArgb(obj.ForeColor_MainText), Color.FromArgb(obj.BackColor_MainText)));
-				//バックスラッシュエスケープ ( Backslash Escapes )
-				_MarkdownSyntaxKeywordAarray.Add(new MarkdownSyntaxKeyword(@"\\:|\\\|", Color.FromArgb(obj.ForeColor_BackslashEscapes), Color.FromArgb(obj.BackColor_BackslashEscapes)));
-			}
-
-		}
-
-
 		//======================================================================
 		#region ブラウザーのツールバーメニュー ( Toolbar on browser )
 		//======================================================================
@@ -2653,7 +2558,6 @@ namespace MarkDownSharpEditor
 			//richTextBoxの書式を変えても「変更」となるので元のステータスへ戻す
 			richTextBox1.Modified = fModify;
 		}
-
 		//-----------------------------------
 		//「オプション」メニュー
 		// "Option" menu
@@ -2664,7 +2568,7 @@ namespace MarkDownSharpEditor
 			frm3.ShowDialog();
 			frm3.Dispose();
 
-			RefreshSyntaxHightlighterKeyword();	 //キーワードリストの更新
+			_MarkdownSyntaxKeywordAarray = MarkdownSyntaxKeyword.CreateKeywordList(); //キーワードリストの更新
 			if (backgroundWorker2.IsBusy == false)
 			{
 				//SyntaxHightlighter on BackgroundWorker

--- a/MarkDownSharpEditor/MarkdownSyntaxKeyword.cs
+++ b/MarkDownSharpEditor/MarkdownSyntaxKeyword.cs
@@ -9,6 +9,9 @@ namespace MarkDownSharpEditor
 	//MarkdownキーワードSyntaxHighlighterクラス
 	class MarkdownSyntaxKeyword
 	{
+		private const string mail_regex = @"<(?:(?:(?:(?:[a-zA-Z0-9_!#\$\%&'*+/=?\^`{}~|\-]+)(?:\.(?:[a-zA-Z0-9_!#\$\%&'*+/=?\^`{}~|\-]+))*)|(?:""(?:\\[^\r\n]|[^\\""])*"")))\@(?:(?:(?:(?:[a-zA-Z0-9_!#\$\%&'*+/=?\^`{}~|\-]+)(?:\.(?:[a-zA-Z0-9_!#\$\%&'*+/=?\^`{}~|\-]+))*)|(?:\[(?:\\\S|[\x21-\x5a\x5e-\x7e])*\])))>";
+		private const string horisontal_regex = @"^(\* ){3,}$|^\*.$|^(- ){3,}|^-{3,}$|^(_ ){3,}$|^_{3,}$";
+
 		private string _RegText;
 		private Color _ForeColor = Color.Black;
 		private Color _BackColor = Color.White;
@@ -56,9 +59,88 @@ namespace MarkDownSharpEditor
 			return BackColor.ToArgb();
 		}
 
+		public static List<MarkdownSyntaxKeyword> CreateKeywordList()
+		{
+			var settings = MarkDownSharpEditor.AppSettings.Instance;
+			var keywords = new List<MarkdownSyntaxKeyword> {
+				//強制ブレーク ( Line break )
+				new MarkdownSyntaxKeyword(@"  $", Color.FromArgb(settings.ForeColor_LineBreak), Color.FromArgb(settings.BackColor_LineBreak)),
+				//見出し１ ( Header 1 )
+				new MarkdownSyntaxKeyword(@"^#[^#]*?$", Color.FromArgb(settings.ForeColor_Headlines[1]), Color.FromArgb(settings.BackColor_Headlines[1])),
+				new MarkdownSyntaxKeyword(@"^.*\n=+$", Color.FromArgb(settings.ForeColor_Headlines[1]), Color.FromArgb(settings.BackColor_Headlines[1])),
+				//見出し２ ( Header 2 )
+				new MarkdownSyntaxKeyword(@"^##[^#]*?$", Color.FromArgb(settings.ForeColor_Headlines[2]), Color.FromArgb(settings.BackColor_Headlines[2])),
+				//見出し３ ( Header 3 )
+				new MarkdownSyntaxKeyword(@"^###[^#]*?$", Color.FromArgb(settings.ForeColor_Headlines[3]), Color.FromArgb(settings.BackColor_Headlines[3])),
+				//見出し４ ( Header 4 )
+				new MarkdownSyntaxKeyword(@"^####[^#]*?$", Color.FromArgb(settings.ForeColor_Headlines[4]), Color.FromArgb(settings.BackColor_Headlines[4])),
+				//見出し５ ( Header 5 )
+				new MarkdownSyntaxKeyword(@"^#####[^#]*?$", Color.FromArgb(settings.ForeColor_Headlines[5]), Color.FromArgb(settings.BackColor_Headlines[5])),
+				//見出し６ ( Header 6 )
+				new MarkdownSyntaxKeyword(@"^#####[^#]*?$", Color.FromArgb(settings.ForeColor_Headlines[6]), Color.FromArgb(settings.BackColor_Headlines[6])),
+				//引用 ( Brockquote )
+				new MarkdownSyntaxKeyword(@"^>.*$", Color.FromArgb(settings.ForeColor_Blockquotes), Color.FromArgb(settings.BackColor_Blockquotes)),
+				//リスト ( Lists )
+				new MarkdownSyntaxKeyword(@"^ {0,3}\*[ \t]+.*$|^ {0,3}\+[ \t]+.*$|^ {0,3}-[ \t]+.*$|^ {0,3}[0-9]+\.[ \t]+.*$", Color.FromArgb(settings.ForeColor_Lists), Color.FromArgb(settings.BackColor_Lists)),
+				//コードブロック ( Code blocks )
+				new MarkdownSyntaxKeyword(@"^ {4,}$|^\t{1,}$", Color.FromArgb(settings.ForeColor_CodeBlocks), Color.FromArgb(settings.BackColor_CodeBlocks)),
+				//罫線 ( Horizontal )
+				new MarkdownSyntaxKeyword(horisontal_regex, Color.FromArgb(settings.ForeColor_Horizontal), Color.FromArgb(settings.BackColor_Horizontal)),
+				//「見出し２」だけは罫線よりも後に
+				// Parse "Header 2" after "Horizontal" 
+				new MarkdownSyntaxKeyword(@"^.+\n-+$", Color.FromArgb(settings.ForeColor_Headlines[2]), Color.FromArgb(settings.BackColor_Headlines[2])),
+				//リンク ( Link )
+				// [an example](http://example.com/ "Title") 
+				new MarkdownSyntaxKeyword(@"\[.*\]\((https?|ftp)(:\/\/[-_.!~*\'()a-zA-Z0-9;\/?:\@&=+\$,%#]+)[\t{1,}| {1,}]"".*""\)", Color.FromArgb(settings.ForeColor_Links), Color.FromArgb(settings.BackColor_Links)),
+				// [This link](http://example.net/)
+				new MarkdownSyntaxKeyword(@"\[.*\]\((https?|ftp)(:\/\/[-_.!~*\'()a-zA-Z0-9;\/?:\@&=+\$,%#]+)\)", Color.FromArgb(settings.ForeColor_Links), Color.FromArgb(settings.BackColor_Links)),
+				// [an example][id] 
+				// [an example] [id]
+				new MarkdownSyntaxKeyword(@"\[.*\]\((https?|ftp)(:\/\/[-_.!~*\'()a-zA-Z0-9;\/?:\@&=+\$,%#]+)\)", Color.FromArgb(settings.ForeColor_Links), Color.FromArgb(settings.BackColor_Links)),
+				// [id]: http://example.com/  "Optional Title Here"
+				new MarkdownSyntaxKeyword(@"\[.*\]:[\t{1,}| {1,}](https?|ftp)(:\/\/[-_.!~*\'()a-zA-Z0-9;\/?:\@&=+\$,%#]+)[\t{1,}| {1,}]"".*""", Color.FromArgb(settings.ForeColor_Links), Color.FromArgb(settings.BackColor_Links)),
+				//強調（em, em, strong, strong）
+				new MarkdownSyntaxKeyword(@"\*.*\*|_.*_|\*\*.*\*\*|__.*__", Color.FromArgb(settings.ForeColor_Emphasis), Color.FromArgb(settings.BackColor_Emphasis)),
+				//ソースコード ( Source code )
+				new MarkdownSyntaxKeyword(@"`.*`", Color.FromArgb(settings.ForeColor_Code), Color.FromArgb(settings.BackColor_Emphasis)),
+				//画像 ( Image )
+				new MarkdownSyntaxKeyword(@"!\[.*\]\(.*\)|!\[.*\]\[.*\]|\[.*\]: .*"".*""", Color.FromArgb(settings.ForeColor_Images), Color.FromArgb(settings.BackColor_Emphasis)),
+				//自動リンク（メールアドレスとURL） ( Auto Links )
+				new MarkdownSyntaxKeyword(@"<(https?|ftp)(:\/\/[-_.!~*\'()a-zA-Z0-9;\/?:\@&=+\$,%#]+)>", Color.FromArgb(settings.ForeColor_Links), Color.FromArgb(settings.BackColor_Links)),
+				new MarkdownSyntaxKeyword(mail_regex, Color.FromArgb(settings.ForeColor_Links), Color.FromArgb(settings.BackColor_Links)),
+				//コメントアウト（複数行含めたコメント全部）( Comment out )
+				new MarkdownSyntaxKeyword(@"<!--((?:.|\n)+)-->", Color.FromArgb(settings.ForeColor_Comments), Color.FromArgb(settings.BackColor_Comments))
+			};
 
-
-
-
+			//-----------------------------------
+			// Markdown "Extra" SyntaxHighlighter
+			//-----------------------------------
+			if (MarkDownSharpEditor.AppSettings.Instance.fMarkdownExtraMode)
+			{
+				//HTMLブロック内のMarkdown記法（Markdown Inside HTML Blocks）
+				keywords.Add(new MarkdownSyntaxKeyword("\\s*markdown\\s*=\\s*(?>([\"\'])(.*?)\\1|([^\\s>]*))()", Color.FromArgb(settings.ForeColor_MarkdownInsideHTMLBlocks), Color.FromArgb(settings.BackColor_MarkdownInsideHTMLBlocks)));
+				keywords.Add(new MarkdownSyntaxKeyword("(</?[\\w:$]+(?:(?=[\\s\"\'/a-zA-Z0-9])(?>\".*?\"|\'.*?\'|.+?)*?)?>|<!--.*?-->|<\\?.*?\\?>|<%.*?%>|<!\\[CDATA\\[.*?\\]\\]>)", Color.FromArgb(settings.ForeColor_MarkdownInsideHTMLBlocks), Color.FromArgb(settings.BackColor_MarkdownInsideHTMLBlocks)));
+				//特殊な属性 ( Special Attributes )
+				keywords.Add(new MarkdownSyntaxKeyword("(^.+?)(?:[ ]+.+?)?[ ]*\n(=+|-+)[ ]*\n+", Color.FromArgb(settings.ForeColor_SpecialAttributes), Color.FromArgb(settings.BackColor_SpecialAttributes)));
+				keywords.Add(new MarkdownSyntaxKeyword("^(\\#{1,6})[ ]*(.+?)[ ]*\\#*(?:[ ]+.+?)?[ ]*\n+", Color.FromArgb(settings.ForeColor_SpecialAttributes), Color.FromArgb(settings.BackColor_SpecialAttributes)));
+				//コードブロック区切り（Fenced Code Blocks）
+				keywords.Add(new MarkdownSyntaxKeyword("(?:\\n|\\A)(~{3,})[ ]*(?:\\.?([-_:a-zA-Z0-9]+)|\\{.+?\\})?[ ]*\\n((?>(?!\\1[ ]*\\n).*\\n+)+)\\1[ ]*\\n", Color.FromArgb(settings.ForeColor_FencedCodeBlocks), Color.FromArgb(settings.BackColor_FencedCodeBlocks)));
+				//表組み ( Tables )
+				keywords.Add(new MarkdownSyntaxKeyword("^[ ]{0,2}[|](.+)\\n[ ]{0,2}[|]([ ]*[-:]+[-| :]*)\\n((?:[ ]*[|].*\\n)*)(?=\\n|\\Z)", Color.FromArgb(settings.ForeColor_Tables), Color.FromArgb(settings.BackColor_Tables)));
+				keywords.Add(new MarkdownSyntaxKeyword("^[ ]{0,2}(\\S.*[|].*)\\n[ ]{0,2}([-:]+[ ]*[|][-| :]*)\\n((?:.*[|].*\\n)*)(?=\\n|\\Z)", Color.FromArgb(settings.ForeColor_Tables), Color.FromArgb(settings.BackColor_Tables)));
+				//定義リスト ( Definition Lists )
+				keywords.Add(new MarkdownSyntaxKeyword("(?>\\A\\n?|(?<=\n\n))(?>(([ ]{0,}((?>.*\\S.*\\n)+)\\n?[ ]{0,}:[ ]+)(?s:.+?)(\\z|\\n{2,}(?=\\S)(?![ ]{0,}(?: \\S.*\\n )+?\\n?[ ]{0,}:[ ]+)(?![ ]{0,}:[ ]+))))", Color.FromArgb(settings.ForeColor_DefinitionLists), Color.FromArgb(settings.BackColor_DefinitionLists)));
+				//脚注 ( Footnotes )
+				keywords.Add(new MarkdownSyntaxKeyword("^[ ]{0,}\\[\\^(.+?)\\][ ]?:[ ]*\n?((?:.+|\n(?!\\[\\^.+?\\]:\\s)(?!\\n+[ ]{0,3}\\S))*)", Color.FromArgb(settings.ForeColor_Footnotes), Color.FromArgb(settings.BackColor_Footnotes)));
+				//省略表記 ( Abbreviations )
+				keywords.Add(new MarkdownSyntaxKeyword("^[ ]{0,}\\*\\[(.+?)\\][ ]?:(.*)", Color.FromArgb(settings.ForeColor_Abbreviations), Color.FromArgb(settings.BackColor_Abbreviations)));
+				//強調表示 : むしろダブルコーテーション内は解除する
+				//Emphasis : Rather than remove the syntaxHighlighter of Emphasis within the double quotes
+				keywords.Add(new MarkdownSyntaxKeyword("\".*?\"", Color.FromArgb(settings.ForeColor_MainText), Color.FromArgb(settings.BackColor_MainText)));
+				//バックスラッシュエスケープ ( Backslash Escapes )
+				keywords.Add(new MarkdownSyntaxKeyword(@"\\:|\\\|", Color.FromArgb(settings.ForeColor_BackslashEscapes), Color.FromArgb(settings.BackColor_BackslashEscapes)));
+			}
+			return keywords;
+		}
 	}
 }


### PR DESCRIPTION
Backslash escape の正規表現が不正で全文字が対象となってしまい、パフォーマンス低下を招いていたので修正しました。
また、テストしにくいので、キーワードリストを作る処理を Form から抜き出しました。
