### PR TITLE
コマンドライン引数でファイル名を相対パスで指定するとエラーが発生

### DIFF
--- a/MarkDownSharpEditor/Form1.cs
+++ b/MarkDownSharpEditor/Form1.cs
@@ -236,7 +236,7 @@ namespace MarkDownSharpEditor
 			{
 				if (File.Exists(cmds[i]) == true)
 				{
-					FileArray.Add(cmds[i]);
+					FileArray.Add(Path.GetFullPath(cmds[i]));
 				}
 			}
 


### PR DESCRIPTION
対象ファイルがフルパスでないとBrowserコントロールへ指定するURLが正しく生成されないのが根本原因です。
コマンドライン引数の解析時点で強制にフルパスにするのが最も手っ取り早いのでその方法で修正してみました。
